### PR TITLE
fix: remove RPMs after installing RPMs, to guarantee cleanup

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -51,21 +51,21 @@ run_scripts() {
 }
 run_scripts "pre"
 
-# Remove RPMs.
-get_yaml_array remove_rpms '.rpm.remove[]'
-if [[ ${#remove_rpms[@]} -gt 0 ]]; then
-    echo "-- Removing RPMs defined in recipe.yml --"
-    echo "Removing: ${remove_rpms[@]}"
-    rpm-ostree override remove "${remove_rpms[@]}"
-    echo "---"
-fi
-
 # Install RPMs.
 get_yaml_array install_rpms '.rpm.install[]'
 if [[ ${#install_rpms[@]} -gt 0 ]]; then
     echo "-- Installing RPMs defined in recipe.yml --"
     echo "Installing: ${install_rpms[@]}"
     rpm-ostree install "${install_rpms[@]}"
+    echo "---"
+fi
+
+# Remove RPMs.
+get_yaml_array remove_rpms '.rpm.remove[]'
+if [[ ${#remove_rpms[@]} -gt 0 ]]; then
+    echo "-- Removing RPMs defined in recipe.yml --"
+    echo "Removing: ${remove_rpms[@]}"
+    rpm-ostree override remove "${remove_rpms[@]}"
     echo "---"
 fi
 


### PR DESCRIPTION
This is necessary because the `rpm-ostree install` command lacks any way to exclude "recommended dependency" packages. It installs everything and the kitchen sink.

Therefore, installing something will often pull in a bunch of unwanted dependencies. The best we can do with the current situation is to run the removal after the install, so that users can remove those unwanted components manually and can be sure that they're actually removed.