### PR TITLE
chore: Bump to Fedora 39 (#186)

### DIFF
--- a/.github/workflows/release-iso.yml
+++ b/.github/workflows/release-iso.yml
@@ -13,17 +13,17 @@ jobs:
     permissions:
       contents: write
     container: 
-      image: fedora:38
+      image: fedora:39
       options: --privileged
     steps:
       - uses: actions/checkout@v4
       - name: Generate ISO  
-        uses: ublue-os/isogenerator@main
+        uses: ublue-os/isogenerator@v2.2.0
         id: isogenerator
         with:
           image-name: ${{ github.event.repository.name }}
           installer-repo: releases
-          installer-major-version: 38
+          installer-major-version: 39
           boot-menu-path: boot_menu.yml
       - name: install github CLI
         run: |

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,7 @@
 # does nothing if the image is built in the cloud.
 
 # !! Warning: changing these might not do anything for you. Read comment above.
-ARG IMAGE_MAJOR_VERSION=38
+ARG IMAGE_MAJOR_VERSION=39
 ARG BASE_IMAGE_URL=ghcr.io/ublue-os/silverblue-main
 
 FROM ${BASE_IMAGE_URL}:${IMAGE_MAJOR_VERSION}

--- a/config/recipe.yml
+++ b/config/recipe.yml
@@ -5,7 +5,7 @@ description: A starting point for further customization of uBlue images. Make yo
 
 # the base image to build on top of (FROM) and the version tag to use
 base-image: ghcr.io/ublue-os/silverblue-main
-image-version: 38 # latest is also supported if you want new updates ASAP
+image-version: 39 # latest is also supported if you want new updates ASAP
 
 # module configuration, executed in order
 # you can include multiple instances of the same module


### PR DESCRIPTION
* Bump release-iso workflow to Fedora 39

* Pin isogenerator version

It is recommended in order to avoid some unexpected changes to the maintainer.

* Update other recipe & containerfile to reflect Fedora 39 change